### PR TITLE
Update README.md to reference the correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Visual Studio extension that compiles LESS, Sass Stylus, JSX, ES6 and CoffeeSc
 files.
 
 Download the extension at the
-[VS Gallery](https://visualstudiogallery.msdn.microsoft.com/3b329021-cd7a-4a01-86fc-714c2d05bb6c)
+[VS Gallery](https://marketplace.visualstudio.com/items?itemName=Failwyn.WebCompiler64)
 
 See the
 [changelog](https://github.com/failwyn/WebCompiler/blob/master/CHANGELOG.md)


### PR DESCRIPTION
The existing link to the Visual Studio Marketplace references the upstream project, which is confusing if you get to the project via GitHub first. This change modifies the link to point to the correct project.