### PR TITLE
The SCSS compile Scss test is failing due to a change of URL

### DIFF
--- a/src/WebCompilerTest/Compile/ScssTest.cs
+++ b/src/WebCompilerTest/Compile/ScssTest.cs
@@ -35,7 +35,7 @@ namespace WebCompilerTest
             var first = result.First();
             Assert.IsTrue(File.Exists("../../artifacts/scss/test.css"));
             Assert.IsTrue(first.CompiledContent.Contains("/*# sourceMappingURL=data:"));
-            Assert.IsTrue(result.ElementAt(1).CompiledContent.Contains("url(foo.png)"));
+            Assert.IsTrue(result.ElementAt(1).CompiledContent.Contains("url(../foo.png)"));
             Assert.IsTrue(result.ElementAt(1).CompiledContent.Contains("-webkit-animation"), "AutoPrefix");
 
             string sourceMap = DecodeSourceMap(first.CompiledContent);


### PR DESCRIPTION
Assuming the code produces the right result then this patch fixes the test to include the ../ prefix